### PR TITLE
[FIX] 메인 화면 carousel 부분 수정

### DIFF
--- a/src/components/MultiCarousel/MultiCarousel.tsx
+++ b/src/components/MultiCarousel/MultiCarousel.tsx
@@ -1,6 +1,6 @@
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
-const responsive = {
+const responsiveStore = {
   superLargeDesktop: {
     breakpoint: { max: 4000, min: 3000 },
     items: 4,
@@ -19,16 +19,36 @@ const responsive = {
   },
 };
 
+const responsiveCourse = {
+  superLargeDesktop: {
+    breakpoint: { max: 4000, min: 3000 },
+    items: 2,
+  },
+  desktop: {
+    breakpoint: { max: 3000, min: 1424 },
+    items: 2,
+  },
+  tablet: {
+    breakpoint: { max: 1424, min: 464 },
+    items: 1,
+  },
+  mobile: {
+    breakpoint: { max: 464, min: 0 },
+    items: 1,
+  },
+};
+
 type Props = {
   children: React.ReactNode;
+  type: 'store' | 'course';
   autoPlay?: boolean;
 };
-export default function MultiCarousel({ children, autoPlay }: Props) {
+export default function MultiCarousel({ children, autoPlay, type }: Props) {
   return (
     <Carousel
       infinite
       autoPlay={autoPlay}
-      responsive={responsive}
+      responsive={type === 'course' ? responsiveCourse : responsiveStore}
       itemClass="m-2"
     >
       {children}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -16,6 +16,7 @@ import Image from '../components/Post/Store/Image';
 import TransPorts from '../components/Post/Course/Transports';
 import Header from '../components/Commons/Header';
 import MultiCarousel from '../components/MultiCarousel/MultiCarousel';
+import SearchTopstore from '../components/Search/SearchTopstore';
 
 const LandingPage = () => {
   const address = useSelector((state: RootState) => state.location);
@@ -78,34 +79,11 @@ const LandingPage = () => {
               </h1>
             </div>
             <article className="flex justify-center">
-              <div className="w-8/12">
-                <MultiCarousel>
+              <div className="w-10/12">
+                <MultiCarousel type={'store'}>
                   {data.map((item) => (
-                    <div
-                      key={item.uuid}
-                      className="cursor-pointer transition-all duration-300 ease-in-out transform shadow-lg hover:shadow-none bg-white"
-                    >
-                      <article className="m-2 ">
-                        <div className="flex justify-center items-center">
-                          {item.representImage ? (
-                            <Image representImage={item.representImage} />
-                          ) : (
-                            <p className="w-[292px] h-[210px] flex justify-center items-center text-sm">
-                              이미지가 아직 준비되지 않았어요!
-                            </p>
-                          )}
-                        </div>
-
-                        <section className="mt-4">
-                          <Name name={item.name} />
-                          {/* <Location location={item.location} /> */}
-                          {/* <Description description={item.description} /> */}
-                          <div className="flex mt-1">
-                            {/* <Category category={item.category} /> */}
-                            {/* <Tags tags={item.tags} /> */}
-                          </div>
-                        </section>
-                      </article>
+                    <div key={item.uuid} className="w-1/5 flex justify-center">
+                      <SearchTopstore item={item as Store} />
                     </div>
                   ))}
                 </MultiCarousel>
@@ -119,8 +97,8 @@ const LandingPage = () => {
               </h1>
             </div>
             <article className="flex justify-center">
-              <div className="w-8/12">
-                <MultiCarousel autoPlay={true}>
+              <div className="w-10/12">
+                <MultiCarousel autoPlay={true} type={'course'}>
                   {courseData.map((item) => (
                     <div
                       key={item.uuid}


### PR DESCRIPTION
## 요약
- course / store 별 carousel을 다르게 설정

### top course
![image](https://github.com/to1step/komatzip-fe/assets/49228858/3817c74e-b85c-4889-9ae0-6848ac1f6a24)

### top store 
![image](https://github.com/to1step/komatzip-fe/assets/49228858/7f5a177c-9316-4a82-8de6-7ba96e9ab27d)

### QHD화면 상 (전체 표시)
![image](https://github.com/to1step/komatzip-fe/assets/49228858/4a363c1f-5dcc-4f0c-9020-5b5fcd4cb5b4)


## 확인시 참고
- 현재 store api에서 3개만 나와서 concat으로 동일한 내용을 합쳐서 보여주면은 내용 표시됨
- top이 무조건 5개 이상 나오는다는 가졍 화면 표시 문제 없음