### PR TITLE
[CHORE] map페이지 헤더 컴포넌트 추가

### DIFF
--- a/src/components/Commons/Header.tsx
+++ b/src/components/Commons/Header.tsx
@@ -3,8 +3,14 @@ import Search from '../Search/Search';
 import { useState, useEffect } from 'react';
 import SideBar from '../Sidebar/SideBar';
 import { GiHamburgerMenu } from 'react-icons/gi';
+import { IoIosArrowBack } from 'react-icons/io';
 
-const Header = () => {
+interface HeaderProps {
+  showTitle: boolean;
+  showIcon: boolean;
+}
+
+const Header = ({ showTitle, showIcon }: HeaderProps) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isSideBarOpen, setIsSideBarOpen] = useState(false);
   const [isBackdropVisible, setIsBackdropVisible] = useState(false);
@@ -34,49 +40,60 @@ const Header = () => {
     <header>
       <nav className="flex-row justify-center items-center">
         <div className="flex-row justify-between items-center">
-          <div className="flex justify-end mb-3">
-            {isLoggedIn ? (
-              <Link
-                to="/logout"
-                className="text-xl my-[30px] mx-[70px] text-orange-200 font-semibold hover:text-orange-900"
-              >
-                Logout
-              </Link>
-            ) : (
-              <Link
-                to="/login"
-                className="text-xl my-[30px] mx-[70px] text-orange-200 font-semibold hover:text-orange-900"
-              >
-                Login
-              </Link>
-            )}
-            <Link
-              to="/mypage"
-              className="text-xl my-[30px] mr-[50px] text-orange-200 font-semibold hover:text-orange-900"
-            >
-              My Page
-            </Link>
+          <div className="flex mb-3">
             <div className="flex items-center">
-              <GiHamburgerMenu
-                className="text-4xl cursor-pointer mr-5 text-orange-200 hover:text-orange-900"
-                onClick={toggleSideBar}
-              />
+              {showIcon && (
+                <Link to="/">
+                  <IoIosArrowBack className="text-[50px] text-orange-200 hover:text-orange-900 ml-20" />
+                </Link>
+              )}
+            </div>
+            <div className="flex ml-auto">
+              {isLoggedIn ? (
+                <Link
+                  to="/logout"
+                  className="text-xl my-[30px] mx-[70px] text-orange-200 font-semibold hover:text-orange-900"
+                >
+                  Logout
+                </Link>
+              ) : (
+                <Link
+                  to="/login"
+                  className="text-xl my-[30px] mx-[70px] text-orange-200 font-semibold hover:text-orange-900"
+                >
+                  Login
+                </Link>
+              )}
+              <Link
+                to="/mypage"
+                className="text-xl my-[30px] mr-[50px] text-orange-200 font-semibold hover:text-orange-900"
+              >
+                My Page
+              </Link>
+              <div className="flex items-center">
+                <GiHamburgerMenu
+                  className="text-4xl cursor-pointer mr-5 text-orange-200 hover:text-orange-900"
+                  onClick={toggleSideBar}
+                />
+              </div>
             </div>
           </div>
-          <h1 className="text-center mb-10">
-            <Link
-              to="/"
-              className="text-7xl font-bold text-orange-200 font-custom-snow-crab"
-            >
-              여기가 수도권
-            </Link>
-          </h1>
+          {showTitle && (
+            <h1 className="text-center mb-10">
+              <Link
+                to="/"
+                className="text-7xl font-bold text-orange-200 font-custom-snow-crab"
+              >
+                여기가 수도권
+              </Link>
+            </h1>
+          )}
         </div>
-        <Search />
+        {showTitle && <Search />}
       </nav>
       {isBackdropVisible && (
         <div // 백드롭
-          className="fixed inset-0 bg-gray-900 bg-opacity-60 z-10"
+          className="fixed inset-0 bg-gray-900 bg-opacity-60 z-20"
           onClick={handleBackdropClick} // 백드롭 클릭 시 닫기
         />
       )}

--- a/src/components/Kakaomap/KakaoMap.tsx
+++ b/src/components/Kakaomap/KakaoMap.tsx
@@ -202,7 +202,7 @@ const KakaoMap: React.FC<KakaoMapProps> = ({}) => {
     <div className="relative">
       <div id="kakao-map" style={{ width: '100vw', height: '100vh' }}>
         <button
-          className="my-position-button bg-blue-400 text-white text-xl font-bold py-3 px-6 rounded absolute bottom-4 left-4 z-10"
+          className="my-position-button bg-blue-400 text-white text-xl font-bold py-3 px-6 rounded absolute bottom-[140px] left-4 z-10"
           onClick={moveToMyPosition}
         >
           현재 위치

--- a/src/components/Sidebar/SideBar.tsx
+++ b/src/components/Sidebar/SideBar.tsx
@@ -1,7 +1,6 @@
 import { FaTimes } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
-// Props의 타입을 명시적으로 지정
 type SideBarProps = {
   onClose: () => void;
 };
@@ -12,7 +11,7 @@ function SideBar({ onClose }: SideBarProps) {
   };
 
   return (
-    <div className="fixed z-20 top-0 right-0 h-full w-64 bg-black text-white shadow-md bg-opacity-60">
+    <div className="fixed z-30 top-0 right-0 h-full w-64 bg-black text-white shadow-md bg-opacity-60">
       <div className="p-4 flex justify-between items-center">
         <h2 className="text-2xl font-semibold mb-0">@@님</h2>
         <div>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -61,7 +61,7 @@ const LandingPage = () => {
       <div className=" bg-amber-700 h-[60vh] bg-cover bg-center">
         <div className="bg-blue-300 bg-opacity-20 h-[60vh]">
           <header>
-            <Header />
+            <Header showTitle={true} showIcon={false} />
           </header>
           {/* <section>
             <p className="mt-3 mb-2 inline-block bg-gradient-to-t from-[#FFF743] via-transparent">

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import KakaoMap from '../components/Kakaomap/KakaoMap';
+import Header from '../components/Commons/Header';
 
 const MapPage: React.FC = () => {
   return (
     <div>
+      <header>
+        <Header showTitle={false} showIcon={true} />
+      </header>
       <KakaoMap />
     </div>
   );

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -50,7 +50,7 @@ const SearchPage = () => {
   // };
   return (
     <main>
-      <Header />
+      <Header showTitle={true} showIcon={false} />
       <section className="text-center">
         <p className="inline-block bg-gradient-to-t from-[#FFF743] via-transparent to-transparent">
           👩🏻‍💻 '{searchQuery}'의 검색결과입니다.


### PR DESCRIPTION
맵 페이지 헤더 컴포넌트 추가 했는데 
Header 컴포넌트에 props를 추가하여 해당 부분의 렌더링을 제어할 수 있게끔 했습니다
랜딩페이지랑 serach페이지는 뒤로가기 아이콘이 필요 없을거 같아 아이콘만 false를 줬고(제목,인풋 : true)
맵 페이지는 제목이랑 인풋이 필요 없을거 같아 아이콘 : true (제목,인풋: false) 로 해 놨습니당

![image](https://github.com/to1step/komatzip-fe/assets/110721887/6041d596-15de-4382-86d3-e652276b86ae)

![image](https://github.com/to1step/komatzip-fe/assets/110721887/aaf84387-9d8a-4495-984c-7c8e1c8ca7b4)

