### PR TITLE
[FIX] 회원가입 오류시 메세지 보이지 않는 부분 처리

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,9 +4,12 @@ import { Provider } from 'react-redux';
 import store from './redux/store';
 import App from './App';
 import './index.css';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <Provider store={store}>
+    <ToastContainer />
     <BrowserRouter>
       <App />
     </BrowserRouter>

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -3,7 +3,7 @@ import LoginBackground from '../../components/background/LoginBackground';
 import axiosInstance from '../../api/apiInstance';
 import MenuBar from '../../components/background/MenuBar';
 import { useNavigate } from 'react-router-dom';
-import { success } from '../../util/toastify';
+import { success, errors } from '../../util/toastify';
 
 const SignUp = () => {
   const navigate = useNavigate();
@@ -23,26 +23,18 @@ const SignUp = () => {
   };
   const [check, setCheck] = useState<boolean>(false);
   const [code, setCode] = useState<string>('');
-  const [errors, setErrors] = useState({});
 
   const onSignupStep1 = async () => {
     try {
       // 유효성 검사
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const validationErrors: any = {};
-
       if (formData.password.length < 12) {
-        validationErrors.passwordLength =
-          '비밀번호는 최소한 12자리 이상이어야 합니다.';
+        errors('비밀번호는 최소한 12자리 이상이어야 합니다.');
+        return;
       }
 
       if (formData.password !== formData.confirmPassword) {
-        validationErrors.passwordMatch = '비밀번호가 일치하지 않습니다.';
-      }
-
-      // 에러가 있는 경우 에러 상태 업데이트
-      if (Object.keys(validationErrors).length > 0) {
-        setErrors(validationErrors);
+        errors('비밀번호가 일치하지 않습니다.');
         return;
       }
 
@@ -58,15 +50,13 @@ const SignUp = () => {
           nickname: formData.username,
         },
       );
+
       if (emailValidation) {
-        validationErrors.emailValidation = '이메일 정보가 이미 존재합니다.';
+        errors('이메일 정보가 이미 존재합니다.');
+        return;
       }
       if (nicknameValidation) {
-        validationErrors.nicknameValidation = '이미 존재하는 닉네임 입니다.';
-      }
-      // 에러가 있는 경우 에러 상태 업데이트
-      if (Object.keys(validationErrors).length > 0) {
-        setErrors(validationErrors);
+        errors('이미 존재하는 닉네임 입니다.');
         return;
       }
 
@@ -77,7 +67,6 @@ const SignUp = () => {
       });
 
       setMode('email-verification');
-      setErrors({});
     } catch (error) {
       console.log(error);
     }
@@ -111,6 +100,7 @@ const SignUp = () => {
         navigate('/login');
       }
     } catch (error) {
+      errors('비밀번호는 최소한 12자리 이상이어야 합니다.');
       console.log(error);
     }
   };

--- a/src/util/toastify.ts
+++ b/src/util/toastify.ts
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 // 성공 알람 ( 초록색 창 )
 export const success = (v?: string) =>
   toast.success(`🦄 ${v ?? 'success!'}`, {
-    position: 'top-center',
+    position: 'top-right',
     autoClose: 4000,
     hideProgressBar: false,
     closeOnClick: true,
@@ -16,7 +16,7 @@ export const success = (v?: string) =>
 // 실패 알람 ( 빨간색 창 )
 export const errors = (v?: string) =>
   toast.error(`🦄 ${v ?? 'error!'}`, {
-    position: 'top-center',
+    position: 'top-right',
     autoClose: 4000,
     hideProgressBar: false,
     closeOnClick: true,
@@ -29,7 +29,7 @@ export const errors = (v?: string) =>
 // 경고 알람 ( 노란색 창 )
 export const warning = (v?: string) =>
   toast.warn(`🦄 ${v ?? 'warning!'}`, {
-    position: 'top-center',
+    position: 'top-right',
     autoClose: 4000,
     hideProgressBar: false,
     closeOnClick: true,
@@ -42,7 +42,7 @@ export const warning = (v?: string) =>
 // 정보 알람
 export const info = (v?: string) =>
   toast.info(`🦄 ${v ?? 'info!'}`, {
-    position: 'top-center',
+    position: 'top-right',
     autoClose: 6000,
     hideProgressBar: false,
     closeOnClick: true,


### PR DESCRIPTION
toastify 화면에 표시되도록 setting확인 후 다시 설정 및 회원가입 중복 체크 등 처리 보이도록 변경

### 예시 아래와 같이 오른쪽 상단에 에러 메세지 및 성공 메세지 표시되도록 변경
![image](https://github.com/to1step/komatzip-fe/assets/49228858/dc98d420-9c20-4052-acd1-8a1fd3a8fbdd)
