### PR TITLE
내 가게 등록 기능

### DIFF
--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -16,14 +16,15 @@ const StoreRegistrationModal = ({
   closeModal,
 }: StoreRegistrationModalProps) => {
   const { control, handleSubmit, register } = useForm<CreateStoreForm>();
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
 
-  const [selectedStartTime] = useState<string>('');
+  // const [selectedStartTime] = useState<string>('');
   const [selectedEndTime] = useState<string>('');
 
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: 'images',
-  });
+  // const { append } = useFieldArray({
+  //   control,
+  //   name: 'images',
+  // });
 
   const modalRef = useRef<HTMLDivElement | null>(null);
 
@@ -45,7 +46,15 @@ const StoreRegistrationModal = ({
 
   const onSubmit: SubmitHandler<CreateStoreForm> = async (data) => {
     try {
-      const response = await axiosInstance.post('/api/v1/stores', data);
+      console.log('보내는 요청은', data);
+      const postData = {
+        ...data,
+        category: selectedCategory,
+        // startTime: null,
+        // endTime: null,
+        // tags: data.tags.map((tag: string) => tag.trim()),
+      };
+      const response = await axiosInstance.post('/api/v1/stores', postData);
 
       if (response.data === 200) {
         console.log('🚀 등록 성공');
@@ -66,11 +75,17 @@ const StoreRegistrationModal = ({
       }}
     >
       <article
-        className="bg-white p-4 rounded shadow-md"
+        className="bg-white p-4 rounded shadow-md
+        "
         onClick={(e) => e.stopPropagation()}
       >
-        <button onClick={closeModal}>X</button>
-        <h2>가게 등록 모달</h2>
+        <button
+          className="flex justify-end items-center ml-auto"
+          onClick={closeModal}
+        >
+          X
+        </button>
+        <h1 className="font-black text-xl text-center">가게 등록 모달</h1>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Controller
             name="name"
@@ -79,7 +94,7 @@ const StoreRegistrationModal = ({
             defaultValue=""
             render={({ field }) => (
               <label>
-                <h3>가게 이름</h3>
+                <h3>가게 이름*</h3>
                 <input type="text" {...field} placeholder="가게 이름 입력" />
               </label>
             )}
@@ -90,12 +105,27 @@ const StoreRegistrationModal = ({
             rules={{ required: true }}
             render={() => (
               <label>
-                <h3>카테고리</h3>
-                <input type="radio" value="식당" {...register('category')} />
+                <h3>카테고리*</h3>
+                <input
+                  type="radio"
+                  value={0}
+                  {...register('category')}
+                  onChange={() => setSelectedCategory(0)}
+                />
                 <button>식당</button>
-                <input type="radio" value="카페" {...register('category')} />
+                <input
+                  type="radio"
+                  value={1}
+                  {...register('category')}
+                  onChange={() => setSelectedCategory(1)}
+                />
                 <button>카페</button>
-                <input type="radio" value="공원" {...register('category')} />
+                <input
+                  type="radio"
+                  value={2}
+                  {...register('category')}
+                  onChange={() => setSelectedCategory(2)}
+                />
                 <button>공원</button>
               </label>
             )}
@@ -120,8 +150,64 @@ const StoreRegistrationModal = ({
             render={({ field }) => (
               <label>
                 <h3>위치</h3>
-                <input type="text" {...field} placeholder="위치 입력" />
+                <input type="textarea" {...field} placeholder="위치 입력" />
               </label>
+            )}
+          />
+          <Controller
+            name="coordinates"
+            control={control}
+            rules={{ required: true }}
+            render={({ field }) => (
+              <label>
+                <h3>위도,경도</h3>
+                <input
+                  type="text"
+                  {...field}
+                  placeholder="위도,경도 순으로 입력"
+                  // value={field.value.join(',')}
+                />
+              </label>
+            )}
+          />
+          {/* <Controller
+            name="representImage"
+            control={control}
+            rules={{ required: false }}
+            render={({ field }) => (
+              <div>
+                <h3>이미지 등록</h3>
+                {field.value && (
+                  <div>
+                    <img
+                      src={field.value}
+                      alt="Representative Image"
+                      style={{ width: '100px', height: 'auto' }}
+                    />
+                    <button type="button" onClick={() => field.onChange(null)}>
+                      이미지 삭제
+                    </button>
+                  </div>
+                )}
+                <input
+                  type="file"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      const reader = new FileReader();
+                      reader.onloadend = () => {
+                        field.onChange(reader.result as string);
+                      };
+                      reader.readAsDataURL(file);
+                    } else {
+                      field.onChange(null);
+                    }
+                  }}
+                />
+                <button type="button" onClick={() => append(null)}>
+                  추가
+                </button>
+              </div>
             )}
           />
           <Controller
@@ -137,15 +223,18 @@ const StoreRegistrationModal = ({
                 <input
                   type="text"
                   placeholder="태그 입력"
-                  onKeyDown={(e) =>
-                    e.key === 'Enter' &&
-                    field.onChange([...field.value, e.currentTarget.value])
-                  }
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      const tag = e.currentTarget.value.trim();
+                      field.onChange([...field.value, tag]);
+                      e.currentTarget.value = '';
+                    }
+                  }}
                 />
                 <ul>
                   {field.value.map((tag, index) => (
                     <li key={index}>
-                      {tag}
+                      <span>{tag}</span>
                       <button
                         type="button"
                         onClick={() =>
@@ -165,27 +254,40 @@ const StoreRegistrationModal = ({
           <Controller
             name="startTime"
             control={control}
+            rules={{ required: false }}
             render={({
               field,
             }: {
-              field: { value: string; onChange: (value: string) => void };
+              field: {
+                value: string | null;
+                onChange: (value: string) => void;
+              };
             }) => (
               <section>
                 <h3>매장 운영 시작 시간</h3>
-                <input type="time" value={selectedStartTime || ''} {...field} />
+                <input
+                  type="time"
+                  value={field.value || ''}
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
               </section>
             )}
           />
           <Controller
             name="endTime"
+            rules={{ required: false }}
             control={control}
             render={({ field }) => (
               <section>
                 <h3>매장 운영 종료 시간</h3>
-                <input type="time" value={selectedEndTime || ''} {...field} />
+                <input
+                  type="time"
+                  value={selectedEndTime || ''}
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
               </section>
             )}
-          />
+          /> */}
           <button type="submit" className="border border-black rounded mr-2">
             등록
           </button>

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -155,9 +155,10 @@ const StoreRegistrationModal = ({
                     Array.isArray(field.value) ? field.value.join(',') : ''
                   }
                   onChange={(e) => {
-                    const values = e.target.value
-                      .split(',')
-                      .map((val) => parseFloat(val.trim()));
+                    const values = e.target.value.split(',').map((val) => {
+                      const parse = parseFloat(val.trim());
+                      return isNaN(parse) ? 0 : parse;
+                    });
                     field.onChange(values);
                   }}
                 />

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -42,10 +42,14 @@ const StoreRegistrationModal = ({
   const onSubmit: SubmitHandler<CreateStoreForm> = async (data) => {
     try {
       console.log('보내는 요청은', data);
+
       const postData = {
         ...data, // TODO: 한 번 더 가공해서 보내기
         category: selectedCategory,
-        // coordinates: [121, 10],
+        // coordinates:
+        //   Array.isArray(data.coordinates) && data.coordinates.length >= 2
+        //     ? data.coordinates.map((i) => parseFloat(i))
+        //     : [0, 0],
         // startTime: null,
         // endTime: null,
         // tags: data.tags.map((tag: string) => tag.trim()),
@@ -83,63 +87,64 @@ const StoreRegistrationModal = ({
         </button>
         <h1 className="font-black text-xl text-center">가게 등록 모달</h1>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Controller
-            name="name"
-            control={control}
-            rules={{ required: true }}
-            defaultValue=""
-            render={({ field }) => (
-              <label>
-                <h3>가게 이름*</h3>
-                <input type="text" {...field} placeholder="가게 이름 입력" />
-              </label>
-            )}
-          />
-          <Controller
-            name="category"
-            control={control}
-            rules={{ required: true }}
-            render={() => (
-              <label>
-                <h3>카테고리*</h3>
-                {['식당', '카페', '공원'].map((category, index) => (
-                  <div key={index}>
-                    <input
-                      type="radio"
-                      value={index}
-                      {...register('category')}
-                      onChange={() => setSelectedCategory(index)}
-                    />
-                    <button>{category}</button>
-                  </div>
-                ))}
-              </label>
-            )}
-          />
-          <Controller
-            name="description"
-            control={control}
-            rules={{ required: true }}
-            defaultValue=""
-            render={({ field }) => (
-              <label>
-                <h3>설명</h3>
-                <input type="textarea" {...field} placeholder="설명 입력" />
-              </label>
-            )}
-          />
-          <Controller
-            name="location"
-            control={control}
-            rules={{ required: true }}
-            defaultValue=""
-            render={({ field }) => (
-              <label>
-                <h3>위치</h3>
-                <input type="textarea" {...field} placeholder="위치 입력" />
-              </label>
-            )}
-          />
+          <label>
+            <h3>가게 이름*</h3>
+            <input
+              type="text"
+              {...register('name', { required: true })}
+              placeholder="가게 이름 입력"
+            />
+          </label>
+
+          <label>
+            <h3>카테고리*</h3>
+            <div>
+              <input
+                type="radio"
+                value={0}
+                {...register('category', { required: true })}
+                onChange={() => setSelectedCategory(0)}
+              />
+              <button>식당</button>
+            </div>
+            <div>
+              <input
+                type="radio"
+                value={1}
+                {...register('category', { required: true })}
+                onChange={() => setSelectedCategory(1)}
+              />
+              <button>카페</button>
+            </div>
+            <div>
+              <input
+                type="radio"
+                value={2}
+                {...register('category', { required: true })}
+                onChange={() => setSelectedCategory(2)}
+              />
+              <button>공원</button>
+            </div>
+          </label>
+
+          <label>
+            <h3>설명</h3>
+            <input
+              type="textarea"
+              {...register('description', { required: true })}
+              placeholder="설명 입력"
+            />
+          </label>
+
+          <label>
+            <h3>위치</h3>
+            <input
+              type="textarea"
+              {...register('location', { required: true })}
+              placeholder="위치 입력"
+            />
+          </label>
+
           <Controller
             name="coordinates"
             control={control}
@@ -165,6 +170,7 @@ const StoreRegistrationModal = ({
               </label>
             )}
           />
+
           {/* <Controller
             name="representImage"
             control={control}

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import {
-  useForm,
-  SubmitHandler,
-  Controller,
-  useFieldArray,
-} from 'react-hook-form';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { CreateStoreForm } from '@to1step/propose-backend';
 import axiosInstance from '../../../api/apiInstance';
 
@@ -19,7 +14,7 @@ const StoreRegistrationModal = ({
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
 
   // const [selectedStartTime] = useState<string>('');
-  const [selectedEndTime] = useState<string>('');
+  // const [selectedEndTime] = useState<string>('');
 
   // const { append } = useFieldArray({
   //   control,
@@ -48,8 +43,9 @@ const StoreRegistrationModal = ({
     try {
       console.log('보내는 요청은', data);
       const postData = {
-        ...data,
+        ...data, // TODO: 한 번 더 가공해서 보내기
         category: selectedCategory,
+        coordinates: [121, 10],
         // startTime: null,
         // endTime: null,
         // tags: data.tags.map((tag: string) => tag.trim()),
@@ -106,27 +102,17 @@ const StoreRegistrationModal = ({
             render={() => (
               <label>
                 <h3>카테고리*</h3>
-                <input
-                  type="radio"
-                  value={0}
-                  {...register('category')}
-                  onChange={() => setSelectedCategory(0)}
-                />
-                <button>식당</button>
-                <input
-                  type="radio"
-                  value={1}
-                  {...register('category')}
-                  onChange={() => setSelectedCategory(1)}
-                />
-                <button>카페</button>
-                <input
-                  type="radio"
-                  value={2}
-                  {...register('category')}
-                  onChange={() => setSelectedCategory(2)}
-                />
-                <button>공원</button>
+                {['식당', '카페', '공원'].map((category, index) => (
+                  <div key={index}>
+                    <input
+                      type="radio"
+                      value={index}
+                      {...register('category')}
+                      onChange={() => setSelectedCategory(index)}
+                    />
+                    <button>{category}</button>
+                  </div>
+                ))}
               </label>
             )}
           />
@@ -165,7 +151,9 @@ const StoreRegistrationModal = ({
                   type="text"
                   {...field}
                   placeholder="위도,경도 순으로 입력"
-                  // value={field.value.join(',')}
+                  value={
+                    Array.isArray(field.value) ? field.value.join(',') : ''
+                  }
                 />
               </label>
             )}

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -50,7 +50,7 @@ const StoreRegistrationModal = ({
         // endTime: null,
         // tags: data.tags.map((tag: string) => tag.trim()),
       };
-      const response = await axiosInstance.post('/api/v1/stores', postData);
+      const response = await axiosInstance.post('/v1/stores', postData);
 
       if (response.data === 200) {
         console.log('🚀 등록 성공');

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useRef } from 'react';
-import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { useEffect, useRef, useState } from 'react';
+import {
+  useForm,
+  SubmitHandler,
+  Controller,
+  useFieldArray,
+} from 'react-hook-form';
 import { CreateStoreForm } from '@to1step/propose-backend';
 import axiosInstance from '../../../api/apiInstance';
 
@@ -10,7 +15,15 @@ interface StoreRegistrationModalProps {
 const StoreRegistrationModal = ({
   closeModal,
 }: StoreRegistrationModalProps) => {
-  const { control, handleSubmit } = useForm<CreateStoreForm>();
+  const { control, handleSubmit, register } = useForm<CreateStoreForm>();
+
+  const [selectedStartTime] = useState<string>('');
+  const [selectedEndTime] = useState<string>('');
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'images',
+  });
 
   const modalRef = useRef<HTMLDivElement | null>(null);
 
@@ -35,11 +48,11 @@ const StoreRegistrationModal = ({
       const response = await axiosInstance.post('/api/v1/stores', data);
 
       if (response.data === 200) {
-        console.log('등록 성공');
+        console.log('🚀 등록 성공');
         //TODO: alert 창으로 변경
       }
     } catch (error) {
-      console.log('등록 실패', error);
+      console.log('🚀 등록 실패', error);
     }
   };
 
@@ -56,9 +69,7 @@ const StoreRegistrationModal = ({
         className="bg-white p-4 rounded shadow-md"
         onClick={(e) => e.stopPropagation()}
       >
-        <button className="absolute top-2 right-2" onClick={closeModal}>
-          X
-        </button>
+        <button onClick={closeModal}>X</button>
         <h2>가게 등록 모달</h2>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Controller
@@ -69,23 +80,22 @@ const StoreRegistrationModal = ({
             render={({ field }) => (
               <label>
                 <h3>가게 이름</h3>
-                <input type="text" {...field} />
+                <input type="text" {...field} placeholder="가게 이름 입력" />
               </label>
             )}
           />
           <Controller
             name="category"
             control={control}
-            defaultValue=""
             rules={{ required: true }}
             render={() => (
               <label>
                 <h3>카테고리</h3>
-                <input type="radio" value="식당" />
+                <input type="radio" value="식당" {...register('category')} />
                 <button>식당</button>
-                <input type="radio" value="카페" />
+                <input type="radio" value="카페" {...register('category')} />
                 <button>카페</button>
-                <input type="radio" value="공원" />
+                <input type="radio" value="공원" {...register('category')} />
                 <button>공원</button>
               </label>
             )}
@@ -98,7 +108,7 @@ const StoreRegistrationModal = ({
             render={({ field }) => (
               <label>
                 <h3>설명</h3>
-                <input type="textarea" {...field} />
+                <input type="textarea" {...field} placeholder="설명 입력" />
               </label>
             )}
           />
@@ -110,12 +120,78 @@ const StoreRegistrationModal = ({
             render={({ field }) => (
               <label>
                 <h3>위치</h3>
-                <input type="text" {...field} />
+                <input type="text" {...field} placeholder="위치 입력" />
               </label>
             )}
           />
-          <button type="submit">등록</button>
-          <button onClick={closeModal}>닫기</button>
+          <Controller
+            name="tags"
+            control={control}
+            defaultValue={[]}
+            rules={{ required: false }}
+            render={({ field }) => (
+              <div>
+                <label>
+                  <h3>태그</h3>
+                </label>
+                <input
+                  type="text"
+                  placeholder="태그 입력"
+                  onKeyDown={(e) =>
+                    e.key === 'Enter' &&
+                    field.onChange([...field.value, e.currentTarget.value])
+                  }
+                />
+                <ul>
+                  {field.value.map((tag, index) => (
+                    <li key={index}>
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          field.onChange(
+                            field.value.filter((_, i) => i !== index),
+                          )
+                        }
+                      >
+                        삭제
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          />
+          <Controller
+            name="startTime"
+            control={control}
+            render={({
+              field,
+            }: {
+              field: { value: string; onChange: (value: string) => void };
+            }) => (
+              <section>
+                <h3>매장 운영 시작 시간</h3>
+                <input type="time" value={selectedStartTime || ''} {...field} />
+              </section>
+            )}
+          />
+          <Controller
+            name="endTime"
+            control={control}
+            render={({ field }) => (
+              <section>
+                <h3>매장 운영 종료 시간</h3>
+                <input type="time" value={selectedEndTime || ''} {...field} />
+              </section>
+            )}
+          />
+          <button type="submit" className="border border-black rounded mr-2">
+            등록
+          </button>
+          <button onClick={closeModal} className="border border-black rounded">
+            닫기
+          </button>
         </form>
       </article>
     </div>

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -45,7 +45,7 @@ const StoreRegistrationModal = ({
       const postData = {
         ...data, // TODO: 한 번 더 가공해서 보내기
         category: selectedCategory,
-        coordinates: [121, 10],
+        // coordinates: [121, 10],
         // startTime: null,
         // endTime: null,
         // tags: data.tags.map((tag: string) => tag.trim()),
@@ -154,6 +154,12 @@ const StoreRegistrationModal = ({
                   value={
                     Array.isArray(field.value) ? field.value.join(',') : ''
                   }
+                  onChange={(e) => {
+                    const values = e.target.value
+                      .split(',')
+                      .map((val) => parseFloat(val.trim()));
+                    field.onChange(values);
+                  }}
                 />
               </label>
             )}

--- a/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
+++ b/src/components/Modal/StoreRegistrationModal/StoreRegistrationModal.tsx
@@ -10,7 +10,7 @@ interface StoreRegistrationModalProps {
 const StoreRegistrationModal = ({
   closeModal,
 }: StoreRegistrationModalProps) => {
-  const { control, handleSubmit, register } = useForm<CreateStoreForm>();
+  const { handleSubmit, register } = useForm<CreateStoreForm>();
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
 
   // const [selectedStartTime] = useState<string>('');
@@ -144,32 +144,6 @@ const StoreRegistrationModal = ({
               placeholder="위치 입력"
             />
           </label>
-
-          <Controller
-            name="coordinates"
-            control={control}
-            rules={{ required: true }}
-            render={({ field }) => (
-              <label>
-                <h3>위도,경도</h3>
-                <input
-                  type="text"
-                  {...field}
-                  placeholder="위도,경도 순으로 입력"
-                  value={
-                    Array.isArray(field.value) ? field.value.join(',') : ''
-                  }
-                  onChange={(e) => {
-                    const values = e.target.value.split(',').map((val) => {
-                      const parse = parseFloat(val.trim());
-                      return isNaN(parse) ? 0 : parse;
-                    });
-                    field.onChange(values);
-                  }}
-                />
-              </label>
-            )}
-          />
 
           {/* <Controller
             name="representImage"


### PR DESCRIPTION
- [x] **coordinates**를 제외한 name, description, location, category 요청 가는 것 확인
(필수 요소 : name, description, location, category, coordinates)
(필수 요소 x : representImage, tags, startTime, endTime)

<img width="304" alt="image" src="https://github.com/to1step/komatzip-fe/assets/119380048/3386467f-deba-4ef1-a582-555f4ec37c5a">

## 🚀 coordinates를 사용할 때 에러나는 부분 원인 예상 -> **해결!**
-> input을 text 하나로 입력받고 있는데 number[]로 보내줘야하기 때문에 에러가 나는 것으로 예상
-> value를 {field.value.join(',')}로 하면 해결되지 않을까 했는데 **실패**

**해결방법**

1. [field.value가 undefined인 상황 -> Array.isArray(field.value)를 사용하여 field.value가 배열인지 확인하고, 배열이 맞으면 join 메서드를 호출하여 값을 연결하고, 배열이 아니면 빈 문자열을 사용하여 값을 설정](https://github.com/to1step/komatzip-fe/pull/49/commits/c431e183e8a315408097ecf017c342dbc0acb202)
2. [','가 입력되지 않는 문제 -> 입력 값을 쉼표로 구분 후, 숫자로 변환되게 수정](https://github.com/to1step/komatzip-fe/pull/49/commits/d74fd521315c572103cdabb5b74f88c625d21f11)
3. [','입력 후 경도를 입력하려고 했을 때 `121,NaN` 이런 식으로 NaN이 자동으로 입력되는 문제-> 부동소수점으로 변환하고 난 결과가 NaN일 때는 기본값으로 0을 사용하도록 작성](https://github.com/to1step/komatzip-fe/pull/49/commits/0b11c6f61e55b8ea893bd9b3e50cf7f802f51984)

### 🚀 representImage를 보낼 때 배열로 보내지는 문제 발생
<img width="134" alt="image" src="https://github.com/to1step/komatzip-fe/assets/119380048/d36f818e-27b2-46c8-a61c-f0d5ef5b3a82">
-> 요청이 갈 때 string이 아니라 배열로 요청이 가는 중인 것을 확인
<br />

```ts
const file = e.target.files?.[0];
```
-> 이렇게 작성을 해서 보내주면 되지 않을까 싶었지만 **실패**
-> 다른 방법 찾아보고 있습니다 😭 (=구현중)