### PR TITLE
매장과 코스, location 허용없이도 rank 호출되게 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,8 @@ function App() {
   const myInfo = useSelector((state: RootState) => state.user);
   const [, setData] = useState<User[]>([]);
 
-  const apiKey = import.meta.env.VITE_REST_API_KEY || '';
+  // const apiKey = import.meta.env.VITE_REST_API_KEY || '';
+  const apiKey = 'a055e717c1cb42e8ee196835ba48dfcf' || '';
 
   useEffect(() => {
     const getMyInfo = async () => {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -17,47 +17,43 @@ const LandingPage = () => {
   const [, setCourseUuid] = useState<string[]>([]);
 
   useEffect(() => {
-    if (address) {
-      axiosInstance
-        .get<Store[]>(
-          `/v1/rank?type=store&region=${encodeURIComponent(address)}`,
-          // `/v1/rank?type=store&region=서울특별시%20강남구`,
-        )
-        .then((response) => {
-          if (response && response.data.length > 0) {
-            setData(response.data); // 순위 정보
-            const uuidArray = response.data.map((item) => {
-              return item.uuid;
-            });
-            setCourseUuid(uuidArray);
-          } else {
-            console.log('서버에서 받은 데이터 없음');
-          }
-        })
-        .catch((error) => {
-          console.log('Topstore 데이터 fetching 중 에러 발생: ', error);
-        });
-    }
+    axiosInstance
+      .get<Store[]>(
+        `/v1/rank?type=store&region=${encodeURIComponent(address)}`,
+        // `/v1/rank?type=store&region=서울특별시%20강남구`,
+      )
+      .then((response) => {
+        if (response && response.data.length > 0) {
+          setData(response.data); // 순위 정보
+          const uuidArray = response.data.map((item) => {
+            return item.uuid;
+          });
+          setCourseUuid(uuidArray);
+        } else {
+          console.log('서버에서 받은 데이터 없음');
+        }
+      })
+      .catch((error) => {
+        console.log('Topstore 데이터 fetching 중 에러 발생: ', error);
+      });
   }, [address]);
 
   useEffect(() => {
-    if (address) {
-      axiosInstance
-        .get<Course[]>(
-          `/v1/rank?type=course&region=${encodeURIComponent(address)}`,
-          // `/v1/rank?type=course&region=서울특별시%20강남구`,
-        )
-        .then((response) => {
-          if (response && response.data.length > 0) {
-            setCourseData(response.data); // 순위 정보
-            const uuidArray = response.data.map((item) => item.uuid);
-            setCourseUuid(uuidArray);
-          }
-        })
-        .catch((error) => {
-          console.log('Topcourse 데이터 fetching 중 에러 발생: ', error);
-        });
-    }
+    axiosInstance
+      .get<Course[]>(
+        `/v1/rank?type=course&region=${encodeURIComponent(address)}`,
+        // `/v1/rank?type=course&region=서울특별시%20강남구`,
+      )
+      .then((response) => {
+        if (response && response.data.length > 0) {
+          setCourseData(response.data); // 순위 정보
+          const uuidArray = response.data.map((item) => item.uuid);
+          setCourseUuid(uuidArray);
+        }
+      })
+      .catch((error) => {
+        console.log('Topcourse 데이터 fetching 중 에러 발생: ', error);
+      });
   }, [address]);
 
   return (


### PR DESCRIPTION
### 수정사항
* 위치를 엑세스하지 않아도 메인페이지에서 랭킹 스토어, 랭킹 코스를 확인할 수 있도록 수정했습니다.

---

### 참고 이미지
<img width="296" alt="image" src="https://github.com/to1step/komatzip-fe/assets/119380048/f328f83e-4e70-4d77-b184-8e901080cb0d">

<img width="1269" alt="image" src="https://github.com/to1step/komatzip-fe/assets/119380048/58dd6b2d-0dfd-488d-bf6d-4e188107eab9">

<img width="1264" alt="image" src="https://github.com/to1step/komatzip-fe/assets/119380048/e49dbf84-ca79-45c0-845d-45f01be3383a">
